### PR TITLE
Add `ListBlobs` subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use model::{
 };
 use services::giant_api;
 use tokio::runtime::Runtime;
+use crate::giant_api::ListBlobsFilter;
 
 mod auth_store;
 mod hash;
@@ -31,12 +32,6 @@ struct Cli {
     /// Set the output format
     #[clap(arg_enum, short, long, default_value_t=OutputFormat::Tsv)]
     format: OutputFormat,
-}
-
-#[derive(ValueEnum, Clone)]
-pub enum ListBlobsFilter {
-    All,
-    InMultiple,
 }
 
 #[derive(Subcommand)]
@@ -234,7 +229,7 @@ fn main() {
                         giant_api::delete_blob(giant_uri, &blob.uri)?;
                         println!("Deleted blob {}", blob.uri);
                     }
-                    blobs = giant_api::get_blobs_in_collection(giant_uri, collection)?;
+                    blobs = giant_api::get_blobs_in_collection(giant_uri, collection, &ListBlobsFilter::All)?;
                 }
 
                 println!("Deleting collection {}", collection);

--- a/src/services/giant_api.rs
+++ b/src/services/giant_api.rs
@@ -3,13 +3,16 @@ use std::path::PathBuf;
 use reqwest::{blocking::Client, header::HeaderMap, StatusCode};
 
 use crate::model::blob::{Blob, BlobResp};
-use crate::{auth_store::{self}, model::{
-    cli_error::CliError,
-    collection::Collection,
-    forms::{create_collection::CreateCollection, create_ingestion::CreateIngestion},
-    lang::Language,
-    uri::Uri,
-}};
+use crate::{
+    auth_store::{self},
+    model::{
+        cli_error::CliError,
+        collection::Collection,
+        forms::{create_collection::CreateCollection, create_ingestion::CreateIngestion},
+        lang::Language,
+        uri::Uri,
+    },
+};
 
 use clap::ValueEnum;
 
@@ -121,12 +124,16 @@ pub fn get_or_insert_ingestion(
 }
 
 // Returns a maximum of 500 blobs per request
-pub fn get_blobs_in_collection(giant_uri: &str, collection: &str, filter: &ListBlobsFilter) -> Result<Vec<Blob>, CliError> {
+pub fn get_blobs_in_collection(
+    giant_uri: &str,
+    collection: &str,
+    filter: &ListBlobsFilter,
+) -> Result<Vec<Blob>, CliError> {
     let client = get_client(giant_uri)?;
     let encoded_collection = encode(collection);
     let in_multiple = match filter {
         ListBlobsFilter::All => "",
-        ListBlobsFilter::InMultiple => "&inMultiple=true"
+        ListBlobsFilter::InMultiple => "&inMultiple=true",
     };
     let url = format!("{giant_uri}/api/blobs?collection={encoded_collection}{in_multiple}");
     let res = client.get(url).send()?;

--- a/src/services/giant_api.rs
+++ b/src/services/giant_api.rs
@@ -3,16 +3,13 @@ use std::path::PathBuf;
 use reqwest::{blocking::Client, header::HeaderMap, StatusCode};
 
 use crate::model::blob::{Blob, BlobResp};
-use crate::{
-    auth_store::{self},
-    model::{
-        cli_error::CliError,
-        collection::Collection,
-        forms::{create_collection::CreateCollection, create_ingestion::CreateIngestion},
-        lang::Language,
-        uri::Uri,
-    },
-};
+use crate::{auth_store::{self}, ListBlobsFilter, model::{
+    cli_error::CliError,
+    collection::Collection,
+    forms::{create_collection::CreateCollection, create_ingestion::CreateIngestion},
+    lang::Language,
+    uri::Uri,
+}};
 
 use urlencoding::encode;
 
@@ -116,10 +113,14 @@ pub fn get_or_insert_ingestion(
 }
 
 // Returns a maximum of 500 blobs per request
-pub fn get_blobs_in_collection(giant_uri: &str, collection: &str) -> Result<Vec<Blob>, CliError> {
+pub fn get_blobs_in_collection(giant_uri: &str, collection: &str, filter: &ListBlobsFilter) -> Result<Vec<Blob>, CliError> {
     let client = get_client(giant_uri)?;
     let encoded_collection = encode(collection);
-    let url = format!("{giant_uri}/api/blobs?collection={encoded_collection}");
+    let in_multiple = match filter {
+        ListBlobsFilter::All => "",
+        ListBlobsFilter::InMultiple => "&in_multiple=true"
+    };
+    let url = format!("{giant_uri}/api/blobs?collection={encoded_collection}{in_multiple}");
 
     let res = client.get(url).send()?;
 

--- a/src/services/giant_api.rs
+++ b/src/services/giant_api.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use reqwest::{blocking::Client, header::HeaderMap, StatusCode};
 
 use crate::model::blob::{Blob, BlobResp};
-use crate::{auth_store::{self}, ListBlobsFilter, model::{
+use crate::{auth_store::{self}, model::{
     cli_error::CliError,
     collection::Collection,
     forms::{create_collection::CreateCollection, create_ingestion::CreateIngestion},
@@ -11,7 +11,15 @@ use crate::{auth_store::{self}, ListBlobsFilter, model::{
     uri::Uri,
 }};
 
+use clap::ValueEnum;
+
 use urlencoding::encode;
+
+#[derive(ValueEnum, Clone)]
+pub enum ListBlobsFilter {
+    All,
+    InMultiple,
+}
 
 pub fn get_client(giant_uri: &str) -> Result<Client, CliError> {
     let auth_token = auth_store::get(giant_uri)?;
@@ -118,12 +126,10 @@ pub fn get_blobs_in_collection(giant_uri: &str, collection: &str, filter: &ListB
     let encoded_collection = encode(collection);
     let in_multiple = match filter {
         ListBlobsFilter::All => "",
-        ListBlobsFilter::InMultiple => "&in_multiple=true"
+        ListBlobsFilter::InMultiple => "&inMultiple=true"
     };
     let url = format!("{giant_uri}/api/blobs?collection={encoded_collection}{in_multiple}");
-
     let res = client.get(url).send()?;
-
     let status = res.status();
 
     if status == StatusCode::OK {


### PR DESCRIPTION
To list blobs in a collection (only up to 500 right now, because of Giant API limits)

You can set a filter param to see only blobs in multiple collections. This defaults to `all`.

e.g.

```
cargo run list-blobs http://localhost:3000 "joe Documents"
```

is the same as

```
cargo run list-blobs --filter all http://localhost:3000 "joe Documents"
```

but you can also pass

```
cargo run list-blobs --filter in-multiple http://localhost:3000 "joe Documents"
```

to use the param introduced in https://github.com/guardian/giant/pull/79