### PR TITLE
Store refreshed token from Giant API response

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,7 @@ fn main() {
             bucket,
             progress_from,
         } => {
-            let client = GiantApiClient::new(giant_uri.clone());
+            let mut client = GiantApiClient::new(giant_uri.clone());
 
             // I'm sure we can do better than this.
             let languages: Vec<Language> = languages
@@ -199,7 +199,7 @@ fn main() {
             collection,
             filter,
         } => {
-            let client = GiantApiClient::new(giant_uri.clone());
+            let mut client = GiantApiClient::new(giant_uri.clone());
             CliResult::new(
                 client.get_blobs_in_collection(collection, filter),
                 FailureExitCode::Api,
@@ -210,7 +210,7 @@ fn main() {
             giant_uri,
             collection,
         } => {
-            let client = GiantApiClient::new(giant_uri.clone());
+            let mut client = GiantApiClient::new(giant_uri.clone());
             let result: Result<(), CliError> = (|| {
                 // Returns a maximum of 500 results,
                 // so we need to loop until we've deleted them all.

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,7 +117,7 @@ fn main() {
             .exit();
         }
         Commands::CheckHash { giant_uri, hash } => {
-            let client = GiantApiClient::new(giant_uri.clone());
+            let mut client = GiantApiClient::new(giant_uri.clone());
             CliResult::new(
                 client.check_hash_exists(hash),
                 FailureExitCode::Api,
@@ -125,7 +125,7 @@ fn main() {
             .print_or_exit(format);
         }
         Commands::CheckFile { giant_uri, path } => {
-            let client = GiantApiClient::new(giant_uri.clone());
+            let mut client = GiantApiClient::new(giant_uri.clone());
             let file_exists = (|| {
                 let hash = hash_file(path.clone())?;
                 client.check_hash_exists(&hash.hash)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
-use crate::giant_api::ListBlobsFilter;
+use crate::giant_api::{GiantApiClient, ListBlobsFilter};
 use clap::{Parser, Subcommand};
+use reqwest::Url;
 use hash::hash_file;
 use ingestion::{
     ingestion_upload::ingestion_upload,
@@ -44,28 +45,28 @@ enum Commands {
     /// Login to the Giant instance at the provided URI with an auth token
     Login {
         /// The URI of your Giant server, e.g. https://playground.pfi.gutools.co.uk
-        giant_uri: String,
+        giant_uri: Url,
         /// Your auth token, found on the about page
         token: String,
     },
     /// Check if the provided hash is in Giant, and you have permission to see it
     CheckHash {
         /// The URI of your Giant server, e.g. https://playground.pfi.gutools.co.uk
-        giant_uri: String,
+        giant_uri: Url,
         /// The resource hash you wish to check exists in Giant
         hash: String,
     },
     /// Check if the provided file is in Giant, and you have permission to see it
     CheckFile {
         /// The URI of your Giant server, e.g. https://playground.pfi.gutools.co.uk
-        giant_uri: String,
+        giant_uri: Url,
         /// The path to the file on your local disk
         path: String,
     },
     /// Upload all files in a directory to Giant
     Ingest {
         /// The URI of your Giant server, e.g. https://playground.pfi.gutools.co.uk
-        giant_uri: String,
+        giant_uri: Url,
         /// The ingestion URI for your upload, in the form "collection/ingestion"
         ingestion_uri: String,
         /// The base path for your upload
@@ -82,7 +83,7 @@ enum Commands {
     /// **Currently only lists up to 500 blobs**
     ListBlobs {
         /// The URI of your Giant server, e.g. https://playground.pfi.gutools.co.uk
-        giant_uri: String,
+        giant_uri: Url,
         /// The collection whose blobs you want to list
         collection: String,
         /// List all blobs, or filter to only those that also exist in collections other
@@ -93,7 +94,7 @@ enum Commands {
     /// Delete a collection and all its contents
     DeleteCollection {
         /// The URI of your Giant server, e.g. https://playground.pfi.gutools.co.uk
-        giant_uri: String,
+        giant_uri: Url,
         /// The collection you want to delete
         collection: String,
     },
@@ -110,22 +111,24 @@ fn main() {
         }
         Commands::Login { giant_uri, token } => {
             CliResult::new(
-                auth_store::set(giant_uri, token),
+                auth_store::set(giant_uri.as_str(), token),
                 FailureExitCode::SetAuthToken,
             )
             .exit();
         }
         Commands::CheckHash { giant_uri, hash } => {
+            let client = GiantApiClient::new(giant_uri.clone());
             CliResult::new(
-                giant_api::check_hash_exists(giant_uri, hash),
+                client.check_hash_exists(hash),
                 FailureExitCode::Api,
             )
             .print_or_exit(format);
         }
         Commands::CheckFile { giant_uri, path } => {
+            let client = GiantApiClient::new(giant_uri.clone());
             let file_exists = (|| {
                 let hash = hash_file(path.clone())?;
-                giant_api::check_hash_exists(giant_uri, &hash.hash)
+                client.check_hash_exists(&hash.hash)
             })();
 
             CliResult::new(file_exists, FailureExitCode::Api).print_or_exit(format);
@@ -138,6 +141,8 @@ fn main() {
             bucket,
             progress_from,
         } => {
+            let client = GiantApiClient::new(giant_uri.clone());
+
             // I'm sure we can do better than this.
             let languages: Vec<Language> = languages
                 .split(',')
@@ -159,11 +164,10 @@ fn main() {
                 };
 
                 let ingestion_uri = Uri::parse(ingestion_uri)?;
-                let collection = giant_api::get_or_insert_collection(giant_uri, &ingestion_uri)?;
+                let collection = client.get_or_insert_collection(&ingestion_uri)?;
 
                 println!("Checking ingestion");
-                giant_api::get_or_insert_ingestion(
-                    giant_uri,
+                client.get_or_insert_ingestion(
                     &ingestion_uri,
                     &collection,
                     path.to_path_buf(),
@@ -195,8 +199,9 @@ fn main() {
             collection,
             filter,
         } => {
+            let client = GiantApiClient::new(giant_uri.clone());
             CliResult::new(
-                giant_api::get_blobs_in_collection(giant_uri, collection, filter),
+                client.get_blobs_in_collection(collection, filter),
                 FailureExitCode::Api,
             )
             .print_or_exit(format);
@@ -205,11 +210,11 @@ fn main() {
             giant_uri,
             collection,
         } => {
+            let client = GiantApiClient::new(giant_uri.clone());
             let result: Result<(), CliError> = (|| {
                 // Returns a maximum of 500 results,
                 // so we need to loop until we've deleted them all.
-                let mut blobs = giant_api::get_blobs_in_collection(
-                    giant_uri,
+                let mut blobs = client.get_blobs_in_collection(
                     collection,
                     &ListBlobsFilter::All,
                 )?;
@@ -231,18 +236,17 @@ fn main() {
                             );
                         }
                         println!("Deleting blob {}", blob.uri);
-                        giant_api::delete_blob(giant_uri, &blob.uri)?;
+                        client.delete_blob(&blob.uri)?;
                         println!("Deleted blob {}", blob.uri);
                     }
-                    blobs = giant_api::get_blobs_in_collection(
-                        giant_uri,
+                    blobs = client.get_blobs_in_collection(
                         collection,
                         &ListBlobsFilter::All,
                     )?;
                 }
 
                 println!("Deleting collection {}", collection);
-                giant_api::delete_collection(giant_uri, collection)?;
+                client.delete_collection(collection)?;
                 println!("Deleted collection {}", collection);
 
                 Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 
 use crate::giant_api::{GiantApiClient, ListBlobsFilter};
 use clap::{Parser, Subcommand};
-use reqwest::Url;
 use hash::hash_file;
 use ingestion::{
     ingestion_upload::ingestion_upload,
@@ -15,6 +14,7 @@ use model::{
     lang::Language,
     uri::Uri,
 };
+use reqwest::Url;
 use services::giant_api;
 use tokio::runtime::Runtime;
 
@@ -118,11 +118,8 @@ fn main() {
         }
         Commands::CheckHash { giant_uri, hash } => {
             let mut client = GiantApiClient::new(giant_uri.clone());
-            CliResult::new(
-                client.check_hash_exists(hash),
-                FailureExitCode::Api,
-            )
-            .print_or_exit(format);
+            CliResult::new(client.check_hash_exists(hash), FailureExitCode::Api)
+                .print_or_exit(format);
         }
         Commands::CheckFile { giant_uri, path } => {
             let mut client = GiantApiClient::new(giant_uri.clone());
@@ -214,10 +211,8 @@ fn main() {
             let result: Result<(), CliError> = (|| {
                 // Returns a maximum of 500 results,
                 // so we need to loop until we've deleted them all.
-                let mut blobs = client.get_blobs_in_collection(
-                    collection,
-                    &ListBlobsFilter::All,
-                )?;
+                let mut blobs =
+                    client.get_blobs_in_collection(collection, &ListBlobsFilter::All)?;
 
                 while !blobs.is_empty() {
                     for blob in blobs {
@@ -239,10 +234,7 @@ fn main() {
                         client.delete_blob(&blob.uri)?;
                         println!("Deleted blob {}", blob.uri);
                     }
-                    blobs = client.get_blobs_in_collection(
-                        collection,
-                        &ListBlobsFilter::All,
-                    )?;
+                    blobs = client.get_blobs_in_collection(collection, &ListBlobsFilter::All)?;
                 }
 
                 println!("Deleting collection {}", collection);

--- a/src/model/uri.rs
+++ b/src/model/uri.rs
@@ -72,6 +72,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn accepts_ingestion_uri() {
         let uri = "collection/ingestion";
         let parsed_uri = Uri::parse(uri);
@@ -83,6 +84,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn accepts_file_uri() {
         let uri = "collection/ingestion/directory/file";
         let parsed_uri = Uri::parse(uri);

--- a/src/services/giant_api.rs
+++ b/src/services/giant_api.rs
@@ -81,7 +81,7 @@ impl GiantApiClient {
         }
     }
 
-    pub fn get_or_insert_collection(&self, ingestion_uri: &Uri) -> Result<Collection, CliError> {
+    pub fn get_or_insert_collection(&mut self, ingestion_uri: &Uri) -> Result<Collection, CliError> {
         let collection = ingestion_uri.collection();
 
         let mut collections_url = self.base_url.clone();
@@ -93,7 +93,7 @@ impl GiantApiClient {
         let mut collection_url = collections_url.clone();
         collection_url.path_segments_mut().unwrap().push(collection);
 
-        let res = self.client.get(collection_url).send()?;
+        let res = self.request(Method::GET, collection_url)?;
         let status = res.status();
 
         if status == StatusCode::UNAUTHORIZED {
@@ -166,7 +166,7 @@ impl GiantApiClient {
 
     // Returns a maximum of 500 blobs per request
     pub fn get_blobs_in_collection(
-        &self,
+        &mut self,
         collection: &str,
         filter: &ListBlobsFilter,
     ) -> Result<Vec<Blob>, CliError> {
@@ -183,7 +183,7 @@ impl GiantApiClient {
         url.query_pairs_mut().append_pair("inMultiple", in_multiple);
         url.query_pairs_mut().append_pair("collection", collection);
 
-        let res = self.client.get(url).send()?;
+        let res = self.request(Method::GET, url)?;
         let status = res.status();
 
         if status == StatusCode::OK {

--- a/src/services/giant_api.rs
+++ b/src/services/giant_api.rs
@@ -29,14 +29,13 @@ pub struct GiantApiClient {
 
 impl GiantApiClient {
     pub fn new(base_url: Url) -> Self {
+        let auth_token = auth_store::get(base_url.as_str()).unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert("Authorization", auth_token.parse().unwrap());
+        let client = Client::builder().default_headers(headers).build().unwrap();
         Self {
-            client: {
-                let auth_token = auth_store::get(base_url.as_str()).unwrap();
-                let mut headers = HeaderMap::new();
-                headers.insert("Authorization", auth_token.parse().unwrap());
-                Client::builder().default_headers(headers).build().unwrap()
-            },
-            base_url,
+            client,
+            base_url
         }
     }
 

--- a/src/services/giant_api.rs
+++ b/src/services/giant_api.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
-use reqwest::{blocking::Client, header::HeaderMap, StatusCode};
+use clap::ValueEnum;
+use reqwest::{blocking::Client, header::HeaderMap, StatusCode, Url};
 
-use crate::model::blob::{Blob, BlobResp};
 use crate::{
     auth_store::{self},
     model::{
@@ -13,10 +13,7 @@ use crate::{
         uri::Uri,
     },
 };
-
-use clap::ValueEnum;
-
-use urlencoding::encode;
+use crate::model::blob::{Blob, BlobResp};
 
 #[derive(ValueEnum, Clone)]
 pub enum ListBlobsFilter {
@@ -24,160 +21,195 @@ pub enum ListBlobsFilter {
     InMultiple,
 }
 
-pub fn get_client(giant_uri: &str) -> Result<Client, CliError> {
-    let auth_token = auth_store::get(giant_uri)?;
-    let mut headers = HeaderMap::new();
-    headers.insert("Authorization", auth_token.parse()?);
-
-    Ok(Client::builder().default_headers(headers).build()?)
+pub struct GiantApiClient {
+    client: Client,
+    base_url: Url,
 }
 
-pub fn check_hash_exists(uri: &str, hash: &str) -> Result<bool, CliError> {
-    let mut url = String::from(uri);
-    url.push_str("/api/resources/");
-    url.push_str(hash);
-    url.push_str("?basic=true");
-
-    let client = get_client(uri)?;
-
-    let res = client.get(url).send()?;
-    let status = res.status();
-
-    if status == 401 {
-        Err(CliError::APIAuthError)
-    } else {
-        Ok(res.status() == 200)
-    }
-}
-
-pub fn get_or_insert_collection(uri: &str, ingestion_uri: &Uri) -> Result<Collection, CliError> {
-    let collection = ingestion_uri.collection();
-    let url = format!("{uri}/api/collections/{collection}");
-
-    let client = get_client(uri)?;
-
-    let res = client.get(url).send()?;
-    let status = res.status();
-
-    if status == StatusCode::UNAUTHORIZED {
-        return Err(CliError::APIAuthError);
+impl GiantApiClient {
+    pub fn new(base_url: Url) -> Self {
+        Self {
+            client: {
+                let auth_token = auth_store::get(base_url.as_str()).unwrap();
+                let mut headers = HeaderMap::new();
+                headers.insert("Authorization", auth_token.parse().unwrap());
+                Client::builder().default_headers(headers).build().unwrap()
+            },
+            base_url,
+        }
     }
 
-    if status == StatusCode::NOT_FOUND {
-        // Insert collection
-        let create_collection = CreateCollection {
-            name: collection.to_owned(),
-        };
-        let url = format!("{uri}/api/collections");
-        let res = client.post(url).json(&create_collection).send()?;
+    pub fn check_hash_exists(&self, hash: &str) -> Result<bool, CliError> {
+        let mut url = self.base_url.clone();
+
+        url.path_segments_mut()
+            .unwrap()
+            .push("api")
+            .push("resources")
+            .push(hash);
+
+        url.query_pairs_mut()
+            .append_pair("basic", "true");
+
+        let res = self.client.get(url).send()?;
+        let status = res.status();
+
+        if status == 401 {
+            Err(CliError::APIAuthError)
+        } else {
+            Ok(res.status() == 200)
+        }
+    }
+
+    pub fn get_or_insert_collection(&self, ingestion_uri: &Uri) -> Result<Collection, CliError> {
+        let collection = ingestion_uri.collection();
+
+        let mut collections_url = self.base_url.clone();
+        collections_url.path_segments_mut()
+            .unwrap()
+            .push("api")
+            .push("collections");
+
+        let mut collection_url = collections_url.clone();
+        collection_url.path_segments_mut().unwrap().push(collection);
+
+        let res = self.client.get(collection_url).send()?;
         let status = res.status();
 
         if status == StatusCode::UNAUTHORIZED {
             return Err(CliError::APIAuthError);
-        } else if status != StatusCode::CREATED {
-            return Err(CliError::UnexpectedResponse(status));
         }
-        Ok(res.json::<Collection>()?)
-    } else {
-        Ok(res.json::<Collection>()?)
+
+        if status == StatusCode::NOT_FOUND {
+            // Insert collection
+            let create_collection = CreateCollection {
+                name: collection.to_owned(),
+            };
+            let res = self.client.post(collections_url).json(&create_collection).send()?;
+            let status = res.status();
+
+            if status == StatusCode::UNAUTHORIZED {
+                return Err(CliError::APIAuthError);
+            } else if status != StatusCode::CREATED {
+                return Err(CliError::UnexpectedResponse(status));
+            }
+            Ok(res.json::<Collection>()?)
+        } else {
+            Ok(res.json::<Collection>()?)
+        }
     }
-}
 
-pub fn get_or_insert_ingestion(
-    uri: &str,
-    ingestion_uri: &Uri,
-    base_collection: &Collection,
-    path: PathBuf,
-    languages: Vec<Language>,
-) -> Result<(), CliError> {
-    let collection = ingestion_uri.collection();
-    let ingestion = ingestion_uri.ingestion();
+    pub fn get_or_insert_ingestion(
+        &self,
+        ingestion_uri: &Uri,
+        base_collection: &Collection,
+        path: PathBuf,
+        languages: Vec<Language>,
+    ) -> Result<(), CliError> {
+        let mut url = self.base_url.clone();
 
-    if base_collection
-        .ingestions
-        .iter()
-        .any(|i| i.uri == ingestion_uri.as_str())
-    {
-        // collection already contains ingestion!
-        Ok(())
-    } else {
-        let client = get_client(uri)?;
-        let url = format!("{uri}/api/collections/{collection}");
+        let collection = ingestion_uri.collection();
+        let ingestion = ingestion_uri.ingestion();
 
-        let create_ingestion = CreateIngestion {
-            path: Some(path),
-            name: Some(ingestion.to_owned()),
-            languages,
-            fixed: Some(false), // This is hardcoded to false in the existing CLI
-            default: Some(false),
+        if base_collection
+            .ingestions
+            .iter()
+            .any(|i| i.uri == ingestion_uri.as_str())
+        {
+            // collection already contains ingestion!
+            Ok(())
+        } else {
+            url.path_segments_mut()
+                .unwrap()
+                .push("api")
+                .push("collections")
+                .push(collection);
+
+            let create_ingestion = CreateIngestion {
+                path: Some(path),
+                name: Some(ingestion.to_owned()),
+                languages,
+                fixed: Some(false), // This is hardcoded to false in the existing CLI
+                default: Some(false),
+            };
+
+            let res = self.client.post(url).json(&create_ingestion).send()?;
+            let status = res.status();
+
+            if status == StatusCode::OK {
+                Ok(())
+            } else {
+                Err(CliError::UnexpectedResponse(status))
+            }
+        }
+    }
+
+    // Returns a maximum of 500 blobs per request
+    pub fn get_blobs_in_collection(
+        &self,
+        collection: &str,
+        filter: &ListBlobsFilter,
+    ) -> Result<Vec<Blob>, CliError> {
+        let mut url = self.base_url.clone();
+        url.path_segments_mut().unwrap()
+            .push("api")
+            .push("blobs");
+
+        let in_multiple = match filter {
+            ListBlobsFilter::InMultiple => "true",
+            ListBlobsFilter::All => "false",
         };
 
-        let res = client.post(url).json(&create_ingestion).send()?;
+        url.query_pairs_mut().append_pair("inMultiple", in_multiple);
+        url.query_pairs_mut().append_pair("collection", collection);
+
+        let res = self.client.get(url).send()?;
         let status = res.status();
 
         if status == StatusCode::OK {
+            let resp = res.json::<BlobResp>()?;
+            Ok(resp.blobs)
+        } else {
+            Err(CliError::UnexpectedResponse(status))
+        }
+    }
+
+    pub fn delete_blob(&self, blob_uri: &str) -> Result<(), CliError> {
+        let mut url = self.base_url.clone();
+        url.path_segments_mut().unwrap()
+            .push("api")
+            .push("blobs")
+            .push(blob_uri);
+
+        // checkChildren=false means we'll delete blobs even if they have
+        // children (i.e. because they're archives and contain further files).
+        url.query_pairs_mut().append_pair("checkChildren", "false");
+
+        let res = self.client.delete(url).send()?;
+
+        let status = res.status();
+
+        if status == StatusCode::NO_CONTENT {
             Ok(())
         } else {
             Err(CliError::UnexpectedResponse(status))
         }
     }
-}
 
-// Returns a maximum of 500 blobs per request
-pub fn get_blobs_in_collection(
-    giant_uri: &str,
-    collection: &str,
-    filter: &ListBlobsFilter,
-) -> Result<Vec<Blob>, CliError> {
-    let client = get_client(giant_uri)?;
-    let encoded_collection = encode(collection);
-    let in_multiple = match filter {
-        ListBlobsFilter::All => "",
-        ListBlobsFilter::InMultiple => "&inMultiple=true",
-    };
-    let url = format!("{giant_uri}/api/blobs?collection={encoded_collection}{in_multiple}");
-    let res = client.get(url).send()?;
-    let status = res.status();
+    pub fn delete_collection(&self, collection: &str) -> Result<(), CliError> {
+        let mut url = self.base_url.clone();
+        url.path_segments_mut().unwrap()
+            .push("api")
+            .push("collections")
+            .push(collection);
 
-    if status == StatusCode::OK {
-        let resp = res.json::<BlobResp>()?;
-        Ok(resp.blobs)
-    } else {
-        Err(CliError::UnexpectedResponse(status))
-    }
-}
+        let res = self.client.delete(url).send()?;
+        let status = res.status();
 
-pub fn delete_blob(giant_uri: &str, blob_uri: &str) -> Result<(), CliError> {
-    // TODO QUESTION: is it wasteful to keep getting this client over and over?
-    let client = get_client(giant_uri)?;
-
-    let encoded_blob_uri = encode(blob_uri);
-
-    // checkChildren=false means we'll delete blobs even if they have
-    // children (i.e. because they're archives and contain further files).
-    let url = format!("{giant_uri}/api/blobs/{encoded_blob_uri}?checkChildren=false");
-
-    let res = client.delete(url).send()?;
-
-    let status = res.status();
-
-    if status == StatusCode::NO_CONTENT {
-        Ok(())
-    } else {
-        Err(CliError::UnexpectedResponse(status))
-    }
-}
-
-pub fn delete_collection(giant_uri: &str, collection: &str) -> Result<(), CliError> {
-    let client = get_client(giant_uri)?;
-    let encoded_collection = encode(collection);
-    let url = format!("{giant_uri}/api/collections/{encoded_collection}");
-    let res = client.delete(url).send()?;
-    let status = res.status();
-
-    if status == StatusCode::NO_CONTENT {
-        Ok(())
-    } else {
-        Err(CliError::UnexpectedResponse(status))
+        if status == StatusCode::NO_CONTENT {
+            Ok(())
+        } else {
+            Err(CliError::UnexpectedResponse(status))
+        }
     }
 }


### PR DESCRIPTION
In the Scala Giant CLI, we store the token returned by the Giant API in the `X-Offer-Authorization` header, meaning we always have a fresh token as long as we don't leave too long between requests:

https://github.com/guardian/giant/blob/8eabc54e9d1f807797bc5c623495c5becb21a2f5/cli/src/main/scala/com/gu/pfi/cli/service/CliHttpClient.scala#L84-L91

This PR adds that functionality to the Rust CLI.

It also refactors the Giant client into a struct with member functions, so we don't need to keeping `new`ing up a client on every API call.
