### PR TITLE
Forward request errors

### DIFF
--- a/src/model/cli_error.rs
+++ b/src/model/cli_error.rs
@@ -7,6 +7,9 @@ use thiserror::Error;
 pub enum CliError {
     #[error("IO Error")]
     Io(#[from] std::io::Error),
+    // We need to see the underlying request error in stderr when the CLI
+    // fails, otherwise we have no idea what happened.
+    // https://docs.rs/thiserror/latest/thiserror/
     #[error(transparent)]
     Request(#[from] reqwest::Error),
     #[error("Header error")]

--- a/src/model/cli_error.rs
+++ b/src/model/cli_error.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 pub enum CliError {
     #[error("IO Error")]
     Io(#[from] std::io::Error),
-    #[error("Request Error")]
+    #[error(transparent)]
     Request(#[from] reqwest::Error),
     #[error("Header error")]
     InvalidHeader(#[from] InvalidHeaderValue),


### PR DESCRIPTION
After many thousands of blob deletions, `delete-collection` tends to fail with `Request Error`.

This is totally useless information, and is the result of throwing away all the information from the underlying `reqwest::Error` when we convert to a `CliError`.

So I've changed the conversion macro to `#[error(transparent)]` which forwards the source and Display methods of `CliError` straight through to the underlying `reqwest::Error`, as per https://docs.rs/thiserror/latest/thiserror/

This gives me stderr lines like:

```
error sending request for url (http://blah/api/blobs?inMultiple=false&collection=blah): error trying to connect: dns error: failed to lookup address information: nodename nor servname provided, or not known
```

instead of

```
Request Error
```