### PR TITLE
Add custom S3 endpoints & support non-shell credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,6 +805,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "aws-config",
+ "aws-endpoint",
  "aws-sdk-s3",
  "aws-smithy-http",
  "base64",
@@ -813,6 +814,7 @@ dependencies = [
  "dirs",
  "flashmap",
  "futures",
+ "http",
  "humantime",
  "indicatif",
  "reflection",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,5 @@ chrono = { version = "0.4.20", features = ["serde"] }
 aws-smithy-http = "0.46.0"
 humantime = "2.1.0"
 flashmap = "0.1.0"
+aws-endpoint = "0.46.0"
+http = "0.2.8"

--- a/src/ingestion/ingestion_upload.rs
+++ b/src/ingestion/ingestion_upload.rs
@@ -32,17 +32,10 @@ pub async fn ingestion_upload(
     ingestion_uri: Uri,
     languages: &Vec<Language>,
     path: impl AsRef<Path>,
-    bucket_name: &str,
-    object_store_endpoint: Option<http::Uri>,
+    s3_client: S3Client,
     progress_reader: ProgressReader,
     format: &OutputFormat,
 ) -> Result<(), CliError> {
-    let s3_client = if let Some(endpoint) = object_store_endpoint {
-        S3Client::from_endpoint(endpoint, bucket_name).await
-    } else {
-        S3Client::new(bucket_name).await
-    };
-
     let (sender, mut receiver) = mpsc::unbounded_channel::<LogMessage>();
 
     // Slightly annoying clone so we can move the format into the background worker

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ enum Commands {
         languages: String,
         /// The bucket you wish to upload to
         bucket: String,
-        /// Override the object store endpoint
+        /// Override the object store endpoint, access key id and secret key must be set as environment variables.
         #[clap(long)]
         object_store_endpoint: Option<http::Uri>,
         /// Continue from a previous ingestion using its log

--- a/src/model/cli_output.rs
+++ b/src/model/cli_output.rs
@@ -36,7 +36,7 @@ impl<T: Serialize + Reflection, E: Error> CliResult<T, E> {
         match self.inner {
             Ok(_) => {}
             Err(e) => {
-                eprintln!("{}", e);
+                eprintln!("{e}");
                 std::process::exit(self.exit_code as i32);
             }
         }
@@ -48,31 +48,31 @@ impl<T: Serialize + Reflection, E: Error> CliResult<T, E> {
                 OutputFormat::Tsv => {
                     match Config::make_config(false, "()".into(), "TRUE".into(), "FALSE".into()) {
                         Ok(config) => match tsv::to_string(&r, config) {
-                            Ok(text) => println!("{}", text),
+                            Ok(text) => println!("{text}"),
                             Err(e) => {
                                 eprintln!("Failed to serialize output");
-                                eprintln!("{}", e);
+                                eprintln!("{e}");
                                 std::process::exit(FailureExitCode::Serialization as i32);
                             }
                         },
                         Err(e) => {
                             eprintln!("Invalid TSV output config, you'll need a new build of this tool to fix this");
-                            eprintln!("{}", e);
+                            eprintln!("{e}");
                             std::process::exit(FailureExitCode::Serialization as i32);
                         }
                     }
                 }
                 OutputFormat::Json => match serde_json::to_string(&r) {
-                    Ok(text) => println!("{}", text),
+                    Ok(text) => println!("{text}"),
                     Err(e) => {
                         eprintln!("Failed to serialize output");
-                        eprintln!("{}", e);
+                        eprintln!("{e}");
                         std::process::exit(FailureExitCode::Serialization as i32);
                     }
                 },
             },
             Err(e) => {
-                eprintln!("{}", e);
+                eprintln!("{e}");
                 std::process::exit(self.exit_code as i32);
             }
         }

--- a/src/model/ingestion_file.rs
+++ b/src/model/ingestion_file.rs
@@ -39,7 +39,7 @@ impl IngestionFile {
         Ok(IngestionFile {
             uri,
             parent_uri,
-            size: metadata.len() as u64,
+            size: metadata.len(),
             last_access_time: Some(metadata.accessed()?.into()),
             last_modified_time: Some(metadata.modified()?.into()),
             creation_time: Some(metadata.created()?.into()),

--- a/src/model/uri.rs
+++ b/src/model/uri.rs
@@ -14,8 +14,7 @@ impl Uri {
             Ok(Uri(uri.to_owned()))
         } else {
             Err(CliError::InputError(format!(
-                "URI must be in the form 'collection/ingestion'. Provided '{}'",
-                uri
+                "URI must be in the form 'collection/ingestion'. Provided '{uri}'"
             )))
         }
     }

--- a/src/services/aws.rs
+++ b/src/services/aws.rs
@@ -1,0 +1,13 @@
+//! Utility functions for dealing with AWS
+
+use aws_config::default_provider::credentials::DefaultCredentialsChain;
+
+pub async fn build_credentials_provider(profile: Option<String>) -> DefaultCredentialsChain {
+    let mut builder = DefaultCredentialsChain::builder();
+
+    if let Some(profile) = profile {
+        builder = builder.profile_name(&profile);
+    }
+
+    builder.build().await
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,2 +1,3 @@
+mod aws;
 pub mod giant_api;
 pub mod s3_client;

--- a/src/services/s3_client.rs
+++ b/src/services/s3_client.rs
@@ -15,13 +15,11 @@ impl S3Client {
     pub async fn new(bucket_name: &str) -> Self {
         let region_provider = Region::new("eu-west-1");
 
-        let credentials_provider = DefaultCredentialsChain::builder()
-            .region(region_provider)
-            .build()
-            .await;
+        let credentials_provider = DefaultCredentialsChain::builder().build().await;
 
         let shared_config = aws_config::from_env()
             .credentials_provider(credentials_provider)
+            .region(region_provider)
             .load()
             .await;
 
@@ -36,10 +34,7 @@ impl S3Client {
     pub async fn from_endpoint(endpoint: http::Uri, bucket_name: &str) -> Self {
         let region_provider = Region::new("eu-west-1");
 
-        let credentials_provider = DefaultCredentialsChain::builder()
-            .region(region_provider)
-            .build()
-            .await;
+        let credentials_provider = DefaultCredentialsChain::builder().build().await;
 
         let shared_config = aws_config::from_env()
             .credentials_provider(credentials_provider)
@@ -50,7 +45,9 @@ impl S3Client {
 
         let s3_config = config::Builder::from(&shared_config)
             .endpoint_resolver(endpoint)
+            .region(region_provider)
             .build();
+
         let client = Client::from_conf(s3_config);
 
         S3Client {


### PR DESCRIPTION
Pretty much Ronseal.

You can now ingest to a non-AWS S3 bucket (aka minio) and you can use normal AWS credential chains.

Tested locally and against playground and it all seems to be in working order.

Also ran `cargo clippy` which is why there's a bit of noise moving from `println!("{}", foo)` to `println!("{foo}")`

