### PR TITLE
Restrict release targets to ARM and x86

### DIFF
--- a/scripts/make-release.sh
+++ b/scripts/make-release.sh
@@ -16,7 +16,8 @@ pushd "$SCRIPT_PATH/.."
 
 VERSION=$(grep '^version =' Cargo.toml | sed 's/version = //g' | sed 's/"//g')
 
-ALL_TRIPLES=$(rustup target list --installed)
+# Some targets do not support async code so we only target ARM and x86
+ALL_TRIPLES=$(rustup target list --installed | grep -E '^(aarch64|x86)')
 
 for TRIPLE in $ALL_TRIPLES; do
     echo ''


### PR DESCRIPTION
## What does this change?

The script that builds the release binaries currently builds for all installed targets.
This breaks if you have a target installed that doesn't support asynchronous code (such as `wasm32-wasi`), so this PR filters out all targets that aren't ARM and x86.

## Why?
We run this script to generate release binaries and integrity hashes for homebrew, so it should work reliably.

## How to test

Run the script :-)
